### PR TITLE
Fixes for modern foundry/dnd5e

### DIFF
--- a/module.json
+++ b/module.json
@@ -46,7 +46,7 @@
         "compatibility": {
           "minimum": "2.3.0",
           "verified": "2.3.1",
-          "maximum": "2.x"
+          "maximum": "2.9.9"
         }
       }
     ]

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -13,22 +13,7 @@ export class COMMON {
     name: NAME,
     path: PATH,
     title: TITLE,
-
-    /* expecting item expansion in 2.2.0 which 
-     * will surely mess with our operations. 
-     * This check is only a warning.
-     */
-    systemCompat: ['2.1.0','2.1.x'], 
   };
-
-  static isValidSystem() {
-    const current = game.system.version;
-
-    const lowValid = !isNewerVersion(COMMON.DATA.systemCompat[0], current);
-    const highValid = !isNewerVersion(current, COMMON.DATA.systemCompat[1]);
-
-    return {lowValid, highValid}
-  }
 
   static buildNotification(type, message) {
     Hooks.once('ready', () => {
@@ -41,22 +26,11 @@ export class COMMON {
 
   /* pre-setup steps */
   static build() {
-    let validBuild = true;
-    const results = COMMON.isValidSystem();
-    if (!results.lowValid) {
-      const msg = `${COMMON.DATA.name}: Detected dnd5e system version as "${game.system.version}". Minimum supported dnd5e system version: "${COMMON.DATA.systemCompat[0]}". Disabling all module operations.`
-      console.error(msg);
-      COMMON.buildNotification('error', msg);
-      validBuild = false;
-    }
-
-    if (!results.highValid) {
-      const msg = `${COMMON.DATA.name}: Detected dnd5e system version as "${game.system.version}". Maximum supported dnd5e system version: "${COMMON.DATA.systemCompat[1]}". Full operation cannot be guaranteed.`
-      console.warn(msg);
-      COMMON.buildNotification('warn', msg);
-      validBuild = true;
-    }
-
+    /* prior to v11, we needed to check the system
+     * version manually. This is no longer needed.
+     * Leaving in-place for potential future use.
+     */
+    const validBuild = true;
     return validBuild;
   }
 

--- a/scripts/modules/damage-roll.js
+++ b/scripts/modules/damage-roll.js
@@ -15,7 +15,7 @@ export class DamageRollSyb5e {
   static hooks() {
     Hooks.on('dnd5e.preRollDamage', (item, rollConfig) => {
       /* inject needed properties (deep impact) */
-      foundry.utils.mergeObject(rollConfig.data.item, {properties: {dim: item.system.properties.dim}});
+      foundry.utils.mergeObject(rollConfig.data.item, {properties: {dim: item.properties.dim}});
     });
   }
 

--- a/scripts/modules/item.js
+++ b/scripts/modules/item.js
@@ -85,7 +85,7 @@ export class ItemSyb5e {
   }
 
   static getProperties() {
-    let props = {};
+    let props = this.system.properties ?? {};
     /* Armor will also have item properties similar to Weapons */
 
     /* is armor type? return syb armor props or the default object

--- a/scripts/modules/spellcasting.js
+++ b/scripts/modules/spellcasting.js
@@ -305,8 +305,8 @@ export class Spellcasting {
         summary: summaryString
       }
 
-      /* hack: force a local update so we can use this data immediately */
-      item.updateSource({[lastCorruptionField]: itemUpdates[lastCorruptionField]});
+      /* temporarily set the gained corruption in the item data for use in damage roll expressions */
+      foundry.utils.setProperty(item, lastCorruptionField, itemUpdates[lastCorruptionField]);
 
       logger.debug('Cached rolled corruption:', itemUpdates);
 


### PR DESCRIPTION
Closes #60 - Proficiency now properly applied to attack rolls. 
Removed manual dnd5e system check as it is now handled by the package manager directly.