### PR TITLE
WIP: Foundry v13 / dnd5e 5.x migration

### DIFF
--- a/module.json
+++ b/module.json
@@ -32,9 +32,9 @@
 		}
 	],
 	"compatibility": {
-		"minimum": "12",
-		"verified": "12.331",
-		"maximum": "12"
+		"minimum": "13",
+		"verified": "13.351",
+		"maximum": "13"
 	},
 	"relationships": {
 		"systems": [
@@ -42,9 +42,8 @@
 				"id": "dnd5e",
 				"type": "system",
 				"compatibility": {
-					"minimum": "3.3.0",
-					"verified": "3.3.1",
-					"maximum": "4"
+					"minimum": "5.0.0",
+					"verified": "5.2.5"
 				}
 			}
 		]

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -168,7 +168,10 @@ export class SYB5E {
   }
 
   static _preTranslateConfig() {
-    globalThis.game.dnd5e.config.limitedUsePeriods.er = COMMON.localize('SYB5E.Rest.Extended');
+    globalThis.game.dnd5e.config.limitedUsePeriods.er = {
+      label: COMMON.localize('SYB5E.Rest.Extended'),
+      abbreviation: 'ER',
+    };
 
     /* Add in "Greater Artifact" rarity for items */
     globalThis.game.dnd5e.config.itemRarity.greaterArtifact = COMMON.localize('SYB5E.Item.Rarity.GreaterArtifact');
@@ -181,34 +184,34 @@ export class SYB5E {
 
     /* Extend dnd5e weapon properties */
     const weaProps = {
-        are: { label: 'SYB5E.Item.WeaponProps.AreaEffect' },
-        bal: { label: 'SYB5E.Item.WeaponProps.Balanced' },
-        crw: { label: 'SYB5E.Item.WeaponProps.Crewed' },
-        con: { label: 'SYB5E.Item.WeaponProps.Concealed' },
-        dim: { label: 'SYB5E.Item.WeaponProps.DeepImpact' },
-        ens: { label: 'SYB5E.Item.WeaponProps.Ensnaring' },
-        imm: { label: 'SYB5E.Item.WeaponProps.Immobile' },
-        msv: { label: 'SYB5E.Item.WeaponProps.Massive' },
-        res: { label: 'SYB5E.Item.WeaponProps.Restraining' },
-        sge: { label: 'SYB5E.Item.WeaponProps.Siege' },
+        are: { label: COMMON.localize('SYB5E.Item.WeaponProps.AreaEffect') },
+        bal: { label: COMMON.localize('SYB5E.Item.WeaponProps.Balanced') },
+        crw: { label: COMMON.localize('SYB5E.Item.WeaponProps.Crewed') },
+        con: { label: COMMON.localize('SYB5E.Item.WeaponProps.Concealed') },
+        dim: { label: COMMON.localize('SYB5E.Item.WeaponProps.DeepImpact') },
+        ens: { label: COMMON.localize('SYB5E.Item.WeaponProps.Ensnaring') },
+        imm: { label: COMMON.localize('SYB5E.Item.WeaponProps.Immobile') },
+        msv: { label: COMMON.localize('SYB5E.Item.WeaponProps.Massive') },
+        res: { label: COMMON.localize('SYB5E.Item.WeaponProps.Restraining') },
+        sge: { label: COMMON.localize('SYB5E.Item.WeaponProps.Siege') },
       }
 
     Reflect.ownKeys(weaProps).forEach( prop => {
       globalThis.game.dnd5e.config.validProperties.weapon.add(prop);
-      globalThis.game.dnd5e.config.itemProperties[prop] = COMMON.translateObject(weaProps[prop]);
+      globalThis.game.dnd5e.config.itemProperties[prop] = weaProps[prop];
     });
 
     /* Extend armor properties */
     const armProps = {
-      con: { label: 'SYB5E.Item.ArmorProps.Concealable' },
-      cmb: { label: 'SYB5E.Item.ArmorProps.Cumbersome' },
-      noi: { label: 'SYB5E.Item.ArmorProps.Noisy' },
-      wei: { label: 'SYB5E.Item.ArmorProps.Weighty' },
+      con: { label: COMMON.localize('SYB5E.Item.ArmorProps.Concealable') },
+      cmb: { label: COMMON.localize('SYB5E.Item.ArmorProps.Cumbersome') },
+      noi: { label: COMMON.localize('SYB5E.Item.ArmorProps.Noisy') },
+      wei: { label: COMMON.localize('SYB5E.Item.ArmorProps.Weighty') },
     }
 
     Reflect.ownKeys(armProps).forEach( prop => {
       globalThis.game.dnd5e.config.validProperties.equipment.add(prop);
-      globalThis.game.dnd5e.config.itemProperties[prop] = COMMON.translateObject(armProps[prop]);
+      globalThis.game.dnd5e.config.itemProperties[prop] = armProps[prop];
     });
 
     /* extend dnd5e damage types
@@ -216,22 +219,28 @@ export class SYB5E {
      */
     foundry.utils.mergeObject(
       globalThis.game.dnd5e.config.damageTypes,
-      COMMON.translateObject({
-        permc: 'SYB5E.Corruption.PermDamage',
-        tempc: 'SYB5E.Corruption.TempDamage',
-      })
+      {
+        permc: {
+          label: COMMON.localize('SYB5E.Corruption.PermDamage'),
+          icon: '',
+        },
+        tempc: {
+          label: COMMON.localize('SYB5E.Corruption.TempDamage'),
+          icon: '',
+        },
+      }
     );
 
     /* add in "None" spell school (mainly for Troll Singer Songs) */
     foundry.utils.mergeObject(
       globalThis.game.dnd5e.config.spellSchools,
-      {  
+      {
         non: {
-          fullKey: "none",
+          fullKey: 'none',
           label: 'None',
           icon: '/icons/svg/cancel.svg',
         }
-      } 
+      }
     );
 
     /* Store new armor properties */
@@ -288,14 +297,14 @@ export class SYB5E {
     foundry.utils.mergeObject(
       globalThis.game.dnd5e.config.creatureTypes, {
         abomination: {
-          label: 'SYB5E.Creature.Abomination',
+          label: COMMON.localize('SYB5E.Creature.Abomination'),
+          plural: COMMON.localize('SYB5E.Creature.Abomination'),
           icon: '/icons/creatures/magical/spirit-undead-ghost-tan-teal.webp',
-          detectAlignment: true,
         },
         phenomenon: {
-          label: 'SYB5E.Creature.Phenomenon',
+          label: COMMON.localize('SYB5E.Creature.Phenomenon'),
+          plural: COMMON.localize('SYB5E.Creature.Phenomenon'),
           icon: '/icons/creatures/magical/spirit-undead-ghost-purple.webp',
-          detectAlignment: true,
         }
       }
     );

--- a/scripts/modules/actor.js
+++ b/scripts/modules/actor.js
@@ -125,7 +125,7 @@ export class ActorSyb5e {
 
 	/* @override */
 	static async longRest(wrapped, { dialog = true, chat = true, newDay = true } = {}, ...args) {
-		const initHd = this.system.attributes.hd;
+		const initHd = this.system.attributes.hd.value;
 		const initHp = this.system.attributes.hp.value;
 		const initCorr = this.corruption.temp;
 
@@ -149,7 +149,7 @@ export class ActorSyb5e {
 			game.syb5e.CONFIG.REST_TYPES.long,
 			chat,
 			newDay,
-			this.system.attributes.hd - initHd,
+			this.system.attributes.hd.value - initHd,
 			this.system.attributes.hp.value - initHp,
 			this.corruption.temp - initCorr
 		);
@@ -158,7 +158,7 @@ export class ActorSyb5e {
 	/* -------------------------------------------- */
 
 	static async shortRest(wrapped, { dialog = true, chat = true, autoHD = false, autoHDThreshold = 3 } = {}, ...args) {
-		const initHd = this.system.attributes.hd;
+		const initHd = this.system.attributes.hd.value;
 		const initHp = this.system.attributes.hp.value;
 		const initCorr = this.corruption.temp;
 
@@ -182,7 +182,7 @@ export class ActorSyb5e {
 			game.syb5e.CONFIG.REST_TYPES.short,
 			chat,
 			false,
-			this.system.attributes.hd - initHd,
+			this.system.attributes.hd.value - initHd,
 			this.system.attributes.hp.value - initHp,
 			this.corruption.temp - initCorr
 		);
@@ -252,7 +252,7 @@ export class ActorSyb5e {
 			current[data.into] += denomUp;
 		}
 
-		return this.update({ 'data.currency': current });
+		return this.update({ 'system.currency': current });
 	}
 
 	/* -------------------------------------------- */

--- a/scripts/modules/damage-roll.js
+++ b/scripts/modules/damage-roll.js
@@ -30,8 +30,8 @@ export class DamageRollSyb5e {
 
     /* if this is a deep impact weapon on a crit, add in an extra '@mod' term */
     if (this.isCritical && this.data.item?.properties?.has('dim')) {
-      this.terms.push(new OperatorTerm({operator: "+"}));
-      this.terms.push(new NumericTerm({number: this.data.mod}, {flavor: COMMON.localize("SYB5E.Item.WeaponProps.DeepImpact")}));
+      this.terms.push(new foundry.dice.terms.OperatorTerm({operator: "+"}));
+      this.terms.push(new foundry.dice.terms.NumericTerm({number: this.data.mod}, {flavor: COMMON.localize("SYB5E.Item.WeaponProps.DeepImpact")}));
       this.options.flavor += ` (${COMMON.localize('SYB5E.Item.WeaponProps.DeepImpact')})`
     }
     

--- a/scripts/modules/resting.js
+++ b/scripts/modules/resting.js
@@ -86,7 +86,7 @@ export class Resting {
     const {hitPointUpdates, hpGain} = Resting._getRestHitPointUpdate(actor, type);
 
     /* get hit die recovery (full recovery ONLY on extended rest) */
-    const {updates: hitDiceUpdates, hitDiceRecovered} = type === restTypes.extended ? actor._getRestHitDiceRecovery({maxHitDice: actor.system.details.level}) : {updates: [], hitDiceRecovered: 0}
+    const {updates: hitDiceUpdates, hitDiceRecovered} = type === restTypes.extended ? actor._getRestHitDiceRecovery({maxHitDice: actor.system.attributes.hd.max}) : {updates: [], hitDiceRecovered: 0}
 
     /* get corruption recovery 1x, 2x, full (short, long, ext) */
     const recovery = Resting._getCorruptionRecovery(actor, type);
@@ -193,11 +193,13 @@ export class Resting {
 /* -------------------------------------------- */
 
   static getErItemUsesRecovery(items) {
-    /* collect any item with 'er' type recharge */
-    const type = 'er';
-
-    const erItems = items.filter( i => i.system.uses?.per === type );
-    const updates = erItems.map( item => { return { _id: item.id, 'system.uses.value': item.system.uses.max } } );
+    /* collect any item with 'er' type recharge (uses.recovery array contains {period: 'er'}) */
+    const erItems = items.filter( i => {
+      const recovery = i.system.uses?.recovery;
+      if (!recovery) return false;
+      return recovery.some(r => r.period === 'er');
+    });
+    const updates = erItems.map( item => { return { _id: item.id, 'system.uses.spent': 0 } } );
 
     return updates;
   }
@@ -274,12 +276,10 @@ export class Resting {
 
   static async expendHitDie(actor, denomination) {
 
-    //FROM DND5E/entity.js#rollHitDie
-
     // If no denomination was provided, choose the first available
     let cls = null;
     if (!denomination) {
-      cls = actor.itemTypes.class.find(c => c.system.hitDiceUsed < c.system.levels);
+      cls = actor.itemTypes.class.find(c => (c.system.hitDiceUsed ?? 0) < c.system.levels);
       if (!cls) return null;
       denomination = cls.system.hitDice;
     }
@@ -287,8 +287,9 @@ export class Resting {
     // Otherwise locate a class (if any) which has an available hit die of the requested denomination
     else {
       cls = actor.items.find(i => {
-        const d = i.system
-        return (d.hitDice === denomination) && ((d.hitDiceUsed || 0) < (d.levels || 1));
+        if (i.type !== 'class') return false;
+        const d = i.system;
+        return (d.hitDice === denomination) && ((d.hitDiceUsed ?? 0) < (d.levels || 1));
       });
     }
 
@@ -301,9 +302,9 @@ export class Resting {
       return null;
     }
 
-    // Adjust actor data
+    // Adjust actor data — in dnd5e 5.x, HD tracking uses spent count
     await cls.update({
-      "system.hitDiceUsed": cls.system.hitDiceUsed + 1
+      "system.hitDiceUsed": (cls.system.hitDiceUsed ?? 0) + 1
     });
   }
 }


### PR DESCRIPTION
## Summary
- Update module compatibility to Foundry v13.351 / dnd5e 5.2.5
- Fix CONFIG extensions for dnd5e 5.x object formats (damageTypes, creatureTypes, limitedUsePeriods, itemProperties)
- Update dice term references to `foundry.dice.terms` namespace
- Fix actor HD references for new `hd` object format (`{value, max, spent}`)
- Fix currency update path (`data.currency` → `system.currency`)
- Update item uses recovery format (`uses.per` → `uses.recovery` array)
- Fix `expendHitDie` for dnd5e 5.x hitDiceUsed handling

## Still TODO
- [ ] Activity System hooks (corruption mechanic — replace removed `preItemUsageConsumption`/`itemUsageConsumption` hooks)
- [ ] Spellcasting patches (AbilityUseDialog removed in 5.x)
- [ ] Actor Sheet migration (AppV2 — `CharacterActorSheet`/`NPCActorSheet`)
- [ ] Item Sheet injection (new hook names, jQuery → vanilla DOM)
- [ ] Dialog/FormApplication migration to AppV2 (Rest dialog, Config app, Import dialog)
- [ ] Journal Sheet migration (JournalSheet → JournalEntrySheet)
- [ ] DamageRoll patch verification
- [ ] Templates & CSS updates for new dnd5e 5.x DOM structure

## Test plan
- [ ] Module loads without console errors in Foundry v13 + dnd5e 5.x
- [ ] Actor sheets render with corruption UI
- [ ] Spell casting generates corruption instead of consuming spell slots
- [ ] Rest mechanics work (short/long/extended)
- [ ] Item sheets show favored/corruption fields
- [ ] Deep Impact weapons add extra crit damage
- [ ] Cross-compatibility (switching sheet class between dnd5e ↔ syb5e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)